### PR TITLE
Select ICs related to brain response and recompose them into raw data.

### DIFF
--- a/jumeg_preprocessing.py
+++ b/jumeg_preprocessing.py
@@ -813,6 +813,7 @@ def apply_ica_select_brain_response(fname_ctps_ics, n_pca_components=None, inclu
         meg_clean.info['description'] += 'Raw recomposed from ctps selected ICA components\
                                           for brain responses only.'
         meg_clean.save(fnclean, overwrite=True)
+        plot_compare_brain_responses(fn_ctps_ics)
 
 
 #######################################################


### PR DESCRIPTION
1. Added function that reads the independent components related to brain response identified by ctps and recomposes data using only these components. 
2. Another function to plot and compare the original raw data and the recomposed raw data is also added. 
3. </b>",ctpsbr"</b> is the suffix for files that have been recomposed using only brain responses identified by ctps. It stands for ctps brain responses. 

Note: The txt file that is produced by apply_ctps_select_ic contains the IC component numbers and not the indices. The apply_ica_select_brain_response functions reads this text file, subtracts 1 to obtain the indices and applies ICA including only these components. 
