### PR TITLE
Unfiltered ecg eog

### DIFF
--- a/jumeg_preprocessing.py
+++ b/jumeg_preprocessing.py
@@ -196,8 +196,8 @@ def apply_ica_cleaning(fname_ica, n_pca_components=None,
         for ECG and EOG rejection 
         (Beware, filtered settings are fixed.)'''
         
-    import mne
-    import os,np
+    import mne,os
+    import numpy as np
 
     fnlist = get_files_from_list(fname_ica)
 


### PR DESCRIPTION
@lukasbreuer @pravsripad @jdammers For some special condition, such as phases relationship computing, we need to reject ECG, EOG and electrical artifacts without filtering raw data. This modifing add the unfiltered condition in function 'apply_ica_cleaning'.
