### PR TITLE
OCARTA & ICA addons

### DIFF
--- a/decompose/dimension_selection.py
+++ b/decompose/dimension_selection.py
@@ -4,7 +4,7 @@
 ----------------------------------------------------------------------
 --- jumeg.decompose.fourier_ica --------------------------------------
 ----------------------------------------------------------------------
- autor      : Lukas Breuer
+ author     : Lukas Breuer
  email      : l.breuer@fz-juelich.de
  last update: 13.11.2015
  version    : 1.0

--- a/decompose/fourier_ica.py
+++ b/decompose/fourier_ica.py
@@ -351,7 +351,7 @@ def apply_stft(origdata, events=[], tpre=0.0, sfreq=1017.25,
                flow=1.0, fhigh=45.0, win_length_sec=1.0,
                overlap_fac=2.0, hamming_data=False,
                remove_outliers=True, fcnoutliers=[],
-               already_epoched=False, zero_mean=False,
+               already_epoched=False, baseline=(None, None),
                verbose=True):
 
     """
@@ -434,8 +434,12 @@ def apply_stft(origdata, events=[], tpre=0.0, sfreq=1017.25,
         else:
             data_win = origdata[:, int(window[0]):int(window[1])]
 
-        if zero_mean:
-            data_win = data_win - np.mean(data_win, axis=-1)[:, np.newaxis]
+        if baseline != (None, None):
+
+            idx_base1 = int((baseline[0] - tpre) * sfreq) if baseline[0] != None else 0
+            idx_base2 = int((baseline[1] - tpre) * sfreq) if baseline[1] != None else -1
+            data_win = data_win - np.mean(data_win[:, idx_base1:idx_base2],
+                                          axis=-1)[:, np.newaxis]
 
         # multiply by a hamming window if necessary
         if hamming_data:

--- a/decompose/group_ica.py
+++ b/decompose/group_ica.py
@@ -4,7 +4,7 @@
 ----------------------------------------------------------------------
 --- jumeg.decompose.group_ica.py -------------------------------------
 ----------------------------------------------------------------------
- autor      : Lukas Breuer
+ author     : Lukas Breuer
  email      : l.breuer@fz-juelich.de
  last update: 27.11.2015
  version    : 1.0
@@ -19,6 +19,7 @@
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 inv_pattern = "-src-meg-inv.fif"
 img_src_group_ica = ",src_group_ICA"
+
 
 
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -215,7 +216,8 @@ def group_fourierICA_src_space(fname_raw, average=False, stim_name=None,
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #  get time courses of FourierICA components
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++
-def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
+def get_group_fourierICA_time_courses(groupICA_obj, event_id=None,
+                                      stim_delay=0):
 
 
     """
@@ -228,6 +230,9 @@ def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
         ----------
         groupICA_obj: either filename of the group ICA object or an
             already swiped groupICA object
+        event_id: Id of the event of interest to be considered in
+            the stimulus channel.
+            default: event_id=None
         stim_delay: stimulus delay in milliseconds
             default: stim_delay=0
     """
@@ -254,10 +259,11 @@ def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
     icasso_obj = groupICA_obj['icasso_obj']
     fourier_ica_obj = groupICA_obj['fourier_ica_obj']
     fn_list = groupICA_obj['fn_list']
+
     if not isinstance(fn_list, list):
         fn_list = [fn_list]
-    nfn_list = len(fn_list)
 
+    nfn_list = len(fn_list)
 
 
     # ------------------------------------------
@@ -276,13 +282,13 @@ def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
 
 
     # check if we have more than one stimulus ID
-    event_id = icasso_obj.event_id
-    if isinstance(event_id, (list, tuple)):
-        nstim = len(event_id)
-    else:
-        nstim = 1
+    if not event_id:
+        event_id = icasso_obj.event_id
+
+    if not isinstance(event_id, (list, tuple)):
         event_id = [event_id]
 
+    nstim = len(event_id)
     temporal_envelope_all = np.empty((nstim, 0)).tolist()
 
 
@@ -353,6 +359,7 @@ def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
 
             idx_start = idx * nwindows
 
+
             # -------------------------------------------
             # loop over all epochs
             # -------------------------------------------
@@ -371,12 +378,14 @@ def get_group_fourierICA_time_courses(groupICA_obj, stim_delay=0):
                     fft_act[:, startfftind:(startfftind+fftsize)] = act[:, iepoch, :]
                     temporal_envelope[idx_start+iepoch, :, :] = fftpack.ifft(fft_act, n=win_ntsl, axis=1).real
                 else:
-                    temporal_envelope = act.transpose([1, 0, 2])
+                    temporal_envelope[idx_start+iepoch, :, :] = act.transpose([1, 0, 2])
+
 
         # -------------------------------------------
         # collecting time courses of interest
         # -------------------------------------------
         temporal_envelope_all[istim].append(temporal_envelope.real)
+
 
 
     return temporal_envelope_all, src_loc, vert, sfreq

--- a/decompose/icasso.py
+++ b/decompose/icasso.py
@@ -4,7 +4,7 @@
 ----------------------------------------------------------------------
 --- jumeg.decompose.fourier_ica --------------------------------------
 ----------------------------------------------------------------------
- autor      : Lukas Breuer
+ author     : Lukas Breuer
  email      : l.breuer@fz-juelich.de
  last update: 27.11.2015
  version    : 1.1
@@ -799,7 +799,7 @@ class JuMEG_icasso(object):
                              tmin_stim=0.0, tmax_stim=1.0, flow=4.0, fhigh=34.0,
                              event_id=1, hamming_data=True, remove_outliers=True,
                              fn_inv=None, contrast_id=[], baseline=(None, None),
-                             zero_mean=False, averaged_epochs=False, verbose=True):
+                             averaged_epochs=False, verbose=True):
 
 
         # ------------------------------------------
@@ -913,7 +913,7 @@ class JuMEG_icasso(object):
                                   win_length_sec=win_length_sec,
                                   hamming_data=hamming_data,
                                   remove_outliers=remove_outliers,
-                                  zero_mean=zero_mean, verbose=verbose)
+                                  baseline=baseline, verbose=verbose)
 
                 if np.any(contrast_id):
                     X_contrast, _ = apply_stft(meg_data, events=contrast_events,
@@ -922,7 +922,7 @@ class JuMEG_icasso(object):
                                                win_length_sec=win_length_sec,
                                                hamming_data=hamming_data,
                                                remove_outliers=remove_outliers,
-                                               zero_mean=zero_mean,
+                                               baseline=baseline,
                                                verbose=verbose)
 
 
@@ -1378,6 +1378,7 @@ class JuMEG_icasso(object):
                                           baseline=baseline, verbose=verbose)
             normalized = False
 
+        self._sfreq = sfreq
         # ------------------------------------------
         # check if PCA dimension is set...if not
         # use MIBS to estimate the dimension

--- a/glassbrain.py
+++ b/glassbrain.py
@@ -37,10 +37,9 @@ class ConnecBrain(surfer.Brain):
                  views=['lat'], show_toolbar=False, offscreen=False,
                  opacity=0.3):
 
-        print hemi
         # Call our main constructor
-        surfer.Brain.__init__(self, subject_id, hemi, surf,
-                              subjects_dir=subjects_dir)
+        surfer.Brain.__init__(self, subject_id, hemi, surf, views=views, curv=curv,
+                              config_opts=config_opts, subjects_dir=subjects_dir)
         #surfer.Brain.__init__(self, subject_id, hemi, surf, curv, title,
         #                            config_opts, figure, subjects_dir,
         #                            views, show_toolbar, offscreen)
@@ -58,7 +57,7 @@ class ConnecBrain(surfer.Brain):
 
     def add_coords(self, coords, map_surface=None, scale_factor=1.5,
                    color="red", alpha=1, name=None, labels=None, hemi=None,
-                   text_size=5):
+                   text_size=5, txt_pos=[1.4, 1.1, 1.1]):
         """
         Plot locations onto the brain surface as spheres.
 
@@ -125,11 +124,11 @@ class ConnecBrain(surfer.Brain):
         if labels is not None:
             tl = []
             for i in xrange(coords.shape[0]):
-                tl.append(mlab.text3d(foci_coords[i, 0]*1.15,
-                                       foci_coords[i, 1]*1.15,
-                                       foci_coords[i, 2]*1.15,
+                tl.append(mlab.text3d(foci_coords[i, 0]*txt_pos[0],
+                                       foci_coords[i, 1]*txt_pos[1],
+                                       foci_coords[i, 2]*txt_pos[2],
                                        labels[i],
-                                       color=(0.9, 0.9, 0.9),
+                                       color=(1.0, 1.0, 1.0),
                                        scale=text_size,
                                        name=name + '_label',
                                        figure=brain['brain']._f))
@@ -138,7 +137,7 @@ class ConnecBrain(surfer.Brain):
 
         self._toggle_render(True, views)
 
-    def add_arrow(self, coords, tube_radius=3.0,
+    def add_arrow(self, coords, map_surface=None, tube_radius=3.0,
                   color="white", alpha=1, name=None, hemi=None):
         """
         Add an arrow across the brain between two co-ordinates
@@ -160,8 +159,19 @@ class ConnecBrain(surfer.Brain):
 
         hemi = self._check_hemi(hemi)
 
-        foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
-        foci_coords = self.geo[hemi].coords[foci_vtxs]
+        if map_surface is None:
+            foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
+            foci_coords = self.geo[hemi].coords[foci_vtxs]
+        else:
+            foci_surf = utils.Surface(self.subject_id, hemi, map_surface,
+                                   subjects_dir=self.subjects_dir)
+            foci_surf.load_geometry()
+            foci_vtxs = utils.find_closest_vertices(foci_surf.coords, coords)
+            foci_coords = self.geo[hemi].coords[foci_vtxs]
+
+
+        # foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
+        # foci_coords = self.geo[hemi].coords[foci_vtxs]
 
 
         # Convert the color code


### PR DESCRIPTION
@jdammers @pravsripad @lukasbreuer @fboers:

- OCARTA: Now OCARTA can also be applied to fif-data from the Elekta Neuromag system (OCARTA is estimated twice, once for gradiometers and once for magnetometers). Note, the usability for CTF data was also implemented but not tested yet.
- ICA: Integrate keyword for dimension reduction. Now the user can chose between ‚AIC‘, ‚BIC‘, ‚GAP‘, ‚explVar‘ ‚MDL‘ and ‚MIBS‘ for dimension reduction
- ECG Peak Detection: Implement code for ECG peak detection (as used in previous IDL implementation) into jumeg_utils.py. Note, at the moment in all implementations on jumeg we use the peak detection provided by MNE.