### PR TITLE
the ica function delects the copy parameter

### DIFF
--- a/jumeg_plot.py
+++ b/jumeg_plot.py
@@ -120,8 +120,7 @@ def plot_performance_artifact_rejection(meg_raw, ica, fnout_fig,
     else:
         meg_clean_given = False
         meg_clean = ica.apply(meg_raw, exclude=ica.exclude,
-                              n_pca_components=ica.n_components_,
-                              copy=True)
+                              n_pca_components=ica.n_components_)
 
     # plotting parameter
     props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)

--- a/jumeg_preprocessing.py
+++ b/jumeg_preprocessing.py
@@ -287,7 +287,7 @@ def apply_ica_cleaning(fname_ica, n_pca_components=None,
 
         # apply cleaning
         meg_clean = ica.apply(meg_raw, exclude=ica.exclude,
-                              n_pca_components=npca, copy=True)
+                              n_pca_components=npca)
         meg_clean.save(fnclean, overwrite=True)
 
         # plot ECG, EOG averages before and after ICA


### PR DESCRIPTION
@pravsripad , the new MNE version, ```ica.apply()``` has deleted the 'copy' parameter.