### PR TITLE
the issue of copy

### DIFF
--- a/jumeg_plot.py
+++ b/jumeg_plot.py
@@ -119,7 +119,7 @@ def plot_performance_artifact_rejection(meg_raw, ica, fnout_fig,
         meg_clean_given = True
     else:
         meg_clean_given = False
-        meg_clean = ica.apply(meg_raw, exclude=ica.exclude,
+        meg_clean = ica.apply(meg_raw.copy(), exclude=ica.exclude,
                               n_pca_components=ica.n_components_)
 
     # plotting parameter

--- a/jumeg_preprocessing.py
+++ b/jumeg_preprocessing.py
@@ -286,7 +286,7 @@ def apply_ica_cleaning(fname_ica, n_pca_components=None,
                 fi_mne_notch.apply_filter(meg_raw._data, picks=picks)
 
         # apply cleaning
-        meg_clean = ica.apply(meg_raw, exclude=ica.exclude,
+        meg_clean = ica.apply(meg_raw.copy(), exclude=ica.exclude,
                               n_pca_components=npca)
         meg_clean.save(fnclean, overwrite=True)
 


### PR DESCRIPTION
@pravsripad , @jdammers . Since in the new version MNE, ```ica.apply()``` has deleted the copy parameters. In Jumeg, if we want the function ```plot_performance_artifact_rejection``` works as we expect, we can not delete the copy parameter simply, otherwise the raw data will be changed after the ```ica.apply``` . What we can do is to send ```raw.copy()``` instead of ```raw``` to ```ica.apply()``` . 