### PR TITLE
Add jumeg rescale func

### DIFF
--- a/examples/plot_shuffle_time_slices.py
+++ b/examples/plot_shuffle_time_slices.py
@@ -1,0 +1,66 @@
+"""
+====================================================
+Shuffle channels' data in the time domain and plot.
+====================================================
+"""
+# Author: Eberhard Eich
+#         Praveen Sripad
+#
+# License: BSD (3-clause)
+
+import numpy as np
+import os.path as op
+import mne
+from jumeg.jumeg_utils import (get_files_from_list, time_shuffle_slices,
+                               channel_indices_from_list)
+
+from mne.datasets import sample
+data_path = sample.data_path()
+raw_fname = str(data_path + '/MEG/sample/sample_audvis_raw.fif')
+
+# shuffle all MEG channels that begin with number 11
+shflchanlist = ['MEG 11..']
+
+# shuffle the whole length of the data
+tmin, tmax = 0., None
+
+# apply the shuffling
+# time_shuffle_slices(raw_fname, shufflechans=shflchanlist, tmin=tmin, tmax=tmax)
+
+plot_things = True
+if plot_things:
+    permname = op.join(op.dirname(raw_fname),
+                       op.basename(raw_fname).split('-')[0]) + ',tperm-raw.fif'
+
+    rawraw = mne.io.Raw(raw_fname,preload=True)
+    shflpick = channel_indices_from_list(rawraw.info['ch_names'][:],
+                                         shflchanlist)
+    procdperm = mne.io.Raw(permname, preload=True)
+
+    figraw = rawraw.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(1,0,0), picks=shflpick)
+    axisraw = figraw.gca()
+    axisraw.set_ylim([-300., -250.])
+    # procdnr.plot_psd(fmin=0.,fmax=300., color=(0,0,1), picks=shflpick)
+    figshfl = procdperm.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(1,0,0), picks=shflpick)
+    axisshfl = figshfl.gca()
+    axisshfl.set_ylim([-300., -250.])
+
+    megpick = mne.pick_types(rawraw.info, meg=True, ref_meg=False, eeg=False, eog=False, stim=False)
+
+    figraw1 = rawraw.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(0,0,1), picks=megpick)
+    axisraw1 = figraw1.gca()
+    axisraw1.set_ylim([-300., -250.])
+
+    figshfl1 = procdperm.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(0,0,1), picks=megpick)
+    axisshfl1 = figshfl1.gca()
+    axisshfl1.set_ylim([-300., -250.])
+
+    megnochgpick = np.setdiff1d(megpick, shflpick)
+
+    figraw2 = rawraw.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(0,1,0), picks=megnochgpick)
+    axisraw2 = figraw2.gca()
+    axisraw2.set_ylim([-300., -250.])
+
+    figshfl2 = procdperm.plot_psd(fmin=0., fmax=300., tmin=0., tmax=None, color=(0,1,0), picks=megnochgpick)
+    axisshfl2 = figshfl2.gca()
+    axisshfl2.set_ylim([-300., -250.])

--- a/jumeg_utils.py
+++ b/jumeg_utils.py
@@ -1457,3 +1457,138 @@ def time_shuffle_slices(fname_raw, shufflechans=None, tmin=None, tmax=None):
         print "Saving '%s'..." % shflname
         raw.save(shflname, overwrite=True)
     return
+
+
+def rescale_data(data, times, baseline, mode='mean', copy=True, verbose=None):
+    """Rescale aka baseline correct data.
+
+    Parameters
+    ----------
+    data : array
+        It can be of any shape. The only constraint is that the last
+        dimension should be time.
+    times : 1D array
+        Time instants is seconds.
+    baseline : tuple or list of length 2, ndarray or None
+        The time interval to apply rescaling / baseline correction.
+        If None do not apply it. If baseline is ``(bmin, bmax)``
+        the interval is between ``bmin`` (s) and ``bmax`` (s).
+        If ``bmin is None`` the beginning of the data is used
+        and if ``bmax is None`` then ``bmax`` is set to the end of the
+        interval. If baseline is ``(None, None)`` the entire time
+        interval is used.
+        If baseline is an array, then the given array will
+        be used for computing the baseline correction i.e. the mean will be
+        computed from the array provided. The array has to be the same length
+        as the time dimension of the data.
+        If baseline is None, no correction is applied.
+    mode : None | 'ratio' | 'zscore' | 'mean' | 'percent' | 'logratio' | 'zlogratio' # noqa
+        Do baseline correction with ratio (power is divided by mean
+        power during baseline) or zscore (power is divided by standard
+        deviation of power during baseline after subtracting the mean,
+        power = [power - mean(power_baseline)] / std(power_baseline)), mean
+        simply subtracts the mean power, percent is the same as applying ratio
+        then mean, logratio is the same as mean but then rendered in log-scale,
+        zlogratio is the same as zscore but data is rendered in log-scale
+        first.
+        If None no baseline correction is applied.
+    copy : bool
+        Whether to return a new instance or modify in place.
+    verbose : bool, str, int, or None
+        If not None, override default verbose level (see mne.verbose).
+
+    Returns
+    -------
+    data_scaled: array
+        Array of same shape as data after rescaling.
+
+    Note
+    ----
+    Function taken from mne.baseline.rescale in mne-python.
+    (https://github.com/mne-tools/mne-python)
+    """
+    data = data.copy() if copy else data
+
+    from mne.baseline import _log_rescale
+    _log_rescale(baseline, mode)
+
+    if baseline is None:
+        return data
+
+    if isinstance(baseline, np.ndarray):
+        if times == baseline.shape:
+            # use baseline array as data
+            # avoid potential "empty slice" warning
+            if data.shape[-1] > 0:
+                mean = np.mean(baseline, axis=-1)[..., None]
+            else:
+                mean = 0  # otherwise we get an ugly nan
+            if mode == 'mean':
+                data -= mean
+            if mode == 'logratio':
+                data /= mean
+                data = np.log10(baseline)  # a value of 1 means 10 times bigger
+            if mode == 'ratio':
+                data /= mean
+            elif mode == 'zscore':
+                std = np.std(baseline, axis=-1)[..., None]
+                data -= mean
+                data /= std
+            elif mode == 'percent':
+                data -= mean
+                data /= mean
+            elif mode == 'zlogratio':
+                data /= mean
+                data = np.log10(baseline)
+                std = np.std(baseline, axis=-1)[..., None]
+                data /= std
+        else:
+            raise ValueError('Size of times and baseline should be the same')
+    else:
+        bmin, bmax = baseline
+        if bmin is None:
+            imin = 0
+        else:
+            imin = np.where(times >= bmin)[0]
+            if len(imin) == 0:
+                raise ValueError('bmin is too large (%s), it exceeds the largest '
+                                 'time value' % (bmin,))
+            imin = int(imin[0])
+        if bmax is None:
+            imax = len(times)
+        else:
+            imax = np.where(times <= bmax)[0]
+            if len(imax) == 0:
+                raise ValueError('bmax is too small (%s), it is smaller than the '
+                                 'smallest time value' % (bmax,))
+            imax = int(imax[-1]) + 1
+        if imin >= imax:
+            raise ValueError('Bad rescaling slice (%s:%s) from time values %s, %s'
+                             % (imin, imax, bmin, bmax))
+
+        # avoid potential "empty slice" warning
+        if data.shape[-1] > 0:
+            mean = np.mean(data[..., imin:imax], axis=-1)[..., None]
+        else:
+            mean = 0  # otherwise we get an ugly nan
+        if mode == 'mean':
+            data -= mean
+        if mode == 'logratio':
+            data /= mean
+            data = np.log10(data)  # a value of 1 means 10 times bigger
+        if mode == 'ratio':
+            data /= mean
+        elif mode == 'zscore':
+            std = np.std(data[..., imin:imax], axis=-1)[..., None]
+            data -= mean
+            data /= std
+        elif mode == 'percent':
+            data -= mean
+            data /= mean
+        elif mode == 'zlogratio':
+            data /= mean
+            data = np.log10(data)
+            std = np.std(data[..., imin:imax], axis=-1)[..., None]
+            data /= std
+
+    return data


### PR DESCRIPTION
Modified mne rescale func used for baseline removal to allow passing a numpy array which can be used as baseline. 
Use case: When it is required to remove prestim around the stimulus from evoked signals around response.