### PR TITLE
Change noise reducer to include specific notch frequencies.

### DIFF
--- a/jumeg_noise_reducer.py
+++ b/jumeg_noise_reducer.py
@@ -550,10 +550,10 @@ def noise_reducer(fname_raw, raw=None, signals=[], noiseref=[], detrending=None,
             if use_refantinotch:
                 rawref = raw.copy().drop_channels(droplist)
                 fltref.notch_filter(notchfrqscln,
-                                    picks=np.array(xrange(nref)), method='iir')
+                                    picks=np.array(xrange(nref)), method='fft')
                 fltref._data = (rawref._data - fltref._data)
             else:
-                fltref.filter(refhp, reflp, picks=np.array(xrange(nref)), method='iir')
+                fltref.filter(refhp, reflp, picks=np.array(xrange(nref)), method='fft')
             tc1 = time.clock()
             tw1 = time.time()
             if verbose:
@@ -884,7 +884,7 @@ def test_noise_reducer():
         fltref = raw.copy().drop_channels(droplist)
         tct = time.clock()
         twt = time.time()
-        fltref.filter(refflt_hpfreq, refflt_lpfreq, picks=np.array(xrange(nref)), method='iir')
+        fltref.filter(refflt_hpfreq, refflt_lpfreq, picks=np.array(xrange(nref)), method='fft')
         tc1 = time.clock()
         tw1 = time.time()
         print "filtering ref-chans  took %.1f ms (%.2f s walltime)" % (1000. * (tc1 - tct), (tw1 - twt))


### PR DESCRIPTION
The default behavior of the notch is now changed 

- instead of including notches at harmonics it'll now use just the specified notch-frequencies, i.e., what used to be refnotch=50 would now require refnotch=[50.,100., 150., 200., 250.]
- notches with harmony are now also possible: refnotch=[50.,60., 100., 150., 200.]
- The list will always be truncated at the Nyquist-freq. 