### PR TITLE
Change info[filename] to filenames[0] in raw object.

### DIFF
--- a/decompose/ocarta.py
+++ b/decompose/ocarta.py
@@ -1613,7 +1613,7 @@ class JuMEG_ocarta(object):
         if meg_raw == None:
             meg_raw = Raw(fn_raw, preload=True, verbose=False)
         else:
-            fn_raw = meg_raw.info['filename']
+            fn_raw = meg_raw.filenames[0]
 
 
         # check input parameter
@@ -1850,5 +1850,3 @@ class JuMEG_ocarta(object):
 #   to simplify the call of the JuMEG_ocarta() help
 # +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ocarta = JuMEG_ocarta()
-
-

--- a/jumeg_iomeg.py
+++ b/jumeg_iomeg.py
@@ -35,7 +35,7 @@ def wrapper_brain_vision2fiff(header_fname):
                                  '/mne_brain_vision2fiff'
     os.system(mne_brain_vision2fiff_path + ' --header ' +
               header_fname + ' --out ' + header_fname.split('.')[0] + '-eeg')
-    # mne_brain_vision2fiff always adds _raw.fif extension 
+    # mne_brain_vision2fiff always adds _raw.fif extension
     # to its files, so it has to be renamed to -eeg.fif.
     os.system('mv %s %s' % (header_fname.split('.')[0] +
                             '-eeg_raw.fif', header_fname.split('.')[0] + '-eeg.fif'))
@@ -192,4 +192,3 @@ def combine_meeg(raw_fname, eeg_fname, flow=0.6, fhigh=200,
 
     # Write the combined FIF file to disk.
     raw.save(raw_fname.split('-')[0] + '-raw.fif', overwrite=True)
-

--- a/jumeg_noise_reducer.py
+++ b/jumeg_noise_reducer.py
@@ -412,7 +412,7 @@ def noise_reducer(fname_raw, raw=None, signals=[], noiseref=[], detrending=None,
         have_input_file = True
     elif raw is not None:
         if raw.info.has_key('filename'):
-            fnraw = [os.path.basename(raw.info['filename'])]
+            fnraw = [os.path.basename(raw.filenames[0])]
         else:
             fnraw = raw._filenames[0]
         warnings.warn('Setting file name from Raw object')
@@ -439,7 +439,7 @@ def noise_reducer(fname_raw, raw=None, signals=[], noiseref=[], detrending=None,
         else:
             # perform sanity check to make sure Raw object and file are same
             if raw.info.has_key('filename'):
-                fnintern = [os.path.basename(raw.info['filename'])]
+                fnintern = [os.path.basename(raw.filenames[0])]
             else:
                 fnintern = raw._filenames[0]
             if os.path.basename(fname) != os.path.basename(fnintern):

--- a/jumeg_plot.py
+++ b/jumeg_plot.py
@@ -578,7 +578,7 @@ def plot_artefact_overview(raw_orig, raw_clean, stim_event_ids=[1],
     eve_output: 'onset' | 'offset' | 'step'
         Whether to report when events start, when events end, or both.
     overview_fname: str | None
-        Name to save the plot generated. (considers raw_clean.info['filename'])
+        Name to save the plot generated. (considers raw_clean.filenames[0])
 
     Notes: Time is always shown in milliseconds (1e3) and the MEG data from mag
         is always in femtoTesla (fT) (1e15)
@@ -591,7 +591,7 @@ def plot_artefact_overview(raw_orig, raw_clean, stim_event_ids=[1],
 
     if not overview_fname:
         try:
-            overview_fname = raw_clean.info['filename'].rsplit('-raw.fif')[0] + ',overview-plot.png'
+            overview_fname = raw_clean.filenames[0].rsplit('-raw.fif')[0] + ',overview-plot.png'
         except:
             overview_fname = 'overview-plot.png'
 

--- a/jumeg_utils.py
+++ b/jumeg_utils.py
@@ -148,7 +148,7 @@ def mark_bads_batch(subject_list, subjects_dir=None):
                 raw = mne.io.Raw(dirname + '/' + raw_fname, preload=True)
                 raw.plot(block=True)
                 print 'The bad channels marked are %s ' % (raw.info['bads'])
-                save_fname = dirname + '/' + raw.info['filename'].split('/')[-1].split('-raw.fif')[0] + '_bcc-raw.fif'
+                save_fname = dirname + '/' + raw.filenames[0].split('/')[-1].split('-raw.fif')[0] + '_bcc-raw.fif'
                 raw.save(save_fname)
     return
 
@@ -215,14 +215,14 @@ def chop_raw_data(raw, start_time=60.0, stop_time=360.0, save=True, return_chop=
         raw = mne.io.Raw(raw, preload=True)
     # Check if data is longer than required chop duration.
     if (raw.n_times / (raw.info['sfreq'])) < (stop_time + start_time):
-        logger.info("The data is not long enough for file %s.") % (raw.info['filename'])
+        logger.info("The data is not long enough for file %s.") % (raw.filenames[0])
         return
     # Obtain indexes for start and stop times.
     assert start_time < stop_time, "Start time is greater than stop time."
     crop = raw.copy().crop(tmin=start_time, tmax=stop_time)
     dur = int((stop_time - start_time) / 60)
     if save:
-        crop.save(crop.info['filename'].split('-raw.fif')[0] + ',' + str(dur) + 'm-raw.fif')
+        crop.save(crop.filenames[0].split('-raw.fif')[0] + ',' + str(dur) + 'm-raw.fif')
     raw.close()
     if return_chop:
          return crop


### PR DESCRIPTION
The raw.info['filename'] reference is deprecated in the latest MNE version. In order to get the filename raw.filenames can be used. 

Caveat: raw.filenames provides a tuple, and it is unclear when more than one filename may exist in the raw object. So, although presently raw.filenames[0] is used in the code, a check maybe be necessary in the future. 

The changes are made for the below files only at the moment, 
decompose/ocarta.py jumeg_iomeg.py jumeg_noise_reducer.py jumeg_plot.py jumeg_utils.py

@fboers please let me know if you have already made changes to the filename references in jumeg_base.py, and epocher related files and are planning to push it (?). 
