### PR TITLE
Cleanup imports.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@
 
 __version__ = '1.0'
 
-from . import jumeg_preprocessing 
+from . import jumeg_preprocessing
 from . import jumeg_math
 from . import jumeg_iomeg
 from . import jumeg_utils

--- a/connectivity/con_circle.py
+++ b/connectivity/con_circle.py
@@ -13,8 +13,6 @@ import os.path as op
 import yaml
 import pickle
 
-import matplotlib.pyplot as plt
-
 from mne.viz import circular_layout
 from mne.viz.utils import plt_show
 from mne.viz.circle import _plot_connectivity_circle_onpick
@@ -130,6 +128,7 @@ def _plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     axes : instance of matplotlib.axes.PolarAxesSubplot
         The subplot handle.
     """
+    import matplotlib.pyplot as plt
     import matplotlib.path as m_path
     import matplotlib.patches as m_patches
 
@@ -373,6 +372,8 @@ def plot_labelled_group_connectivity_circle(yaml_fname, con, node_order_size=68,
     groups in the yaml input file provided.
     '''
 
+    import matplotlib.pyplot as plt
+
     # load the label names in the original order (aparc)
     labels_fname = get_jumeg_path() + '/examples/label_names.list'
     with open(labels_fname, 'r') as f:
@@ -482,6 +483,7 @@ def plot_fica_grouped_circle(yaml_fname, con, node_order_size,
           be removed.
     '''
 
+    import matplotlib.pyplot as plt
     # load the label names in the original order
     # TODO remove empty lines / strings if any
     # TODO remove below code from here

--- a/connectivity/con_viz.py
+++ b/connectivity/con_viz.py
@@ -6,7 +6,6 @@ import sys
 import os.path as op
 import numpy as np
 import scipy as sci
-import matplotlib.pyplot as pl
 import mne
 import yaml
 import pickle
@@ -195,6 +194,7 @@ def plot_generic_grouped_circle(yaml_fname, con, orig_labels,
     orig_labels : list of str
         Label names in the order as appears in con.
     '''
+    import matplotlib.pyplot as pl
     # read the yaml file with grouping
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:

--- a/connectivity/cross_frequency_coupling.py
+++ b/connectivity/cross_frequency_coupling.py
@@ -5,7 +5,6 @@
 
 import numpy as np
 from scipy.signal import hilbert
-import matplotlib.pyplot as pl
 import mne
 from mne.filter import band_pass_filter
 
@@ -78,7 +77,7 @@ def compute_and_plot_psd(data, sfreq, NFFT=512, show=True):
     freqs : ndarray
         Frequencies.
     """
-
+    import matplotlib.pyplot as pl
     if show is False:
         pl.ioff()
     power, freqs = pl.psd(data, Fs=sfreq, NFFT=NFFT)
@@ -165,6 +164,7 @@ def average_envelope_versus_phase(amplitude_envelope, phase):
         a_std[l] = np.std(amplitude_envelope[indices])
         angle[l] = k + 5
 
+    import matplotlib.pyplot as pl
     pl.figure('Average envelope versus phase')
     pl.plot(angle, a_mean, 'b')
     pl.fill_between(angle, a_mean + a_std, a_mean - a_std, color='gray')
@@ -210,6 +210,7 @@ def event_related_average(gamma, data, win=100, show=True):
         avg[i, :] = data[locs[i] - win: locs[i] + win]
 
     average = np.mean(avg, axis=0)
+    import matplotlib.pyplot as pl
     pl.plot(range(-win, win), average)
     return average
 

--- a/decompose/__init__.py
+++ b/decompose/__init__.py
@@ -75,13 +75,15 @@ Feb. 2014 (doi:10.1109/TBME.2013.2280143).
 ----------------------------------------------------------------------
 """
 
-from . import complex_ica
-from . import dimension_selection
-from . import fourier_ica
-from . import fourier_ica_plot
-from . import group_ica
-from . import ica
-from . import icasso
-from . import ocarta
+from .complex_ica import complex_ica
+# from . import dimension_selection
+from .fourier_ica import (apply_ICASSO_fourierICA, apply_stft,
+                          JuMEG_fourier_ica, stft_source_localization, fourier_ica)
+# from . import fourier_ica_plot
+from .group_ica import (group_fourierICA_src_space,
+                        group_fourierICA_src_space_resting_state, plot_group_fourierICA)
+# from . import ica
+from .icasso import JuMEG_icasso
+from .ocarta import JuMEG_ocarta
 
 

--- a/filter/__init__.py
+++ b/filter/__init__.py
@@ -4,7 +4,3 @@
 #--- License: Simplified BSD
 
 from .jumeg_filter import jumeg_filter
-#from . import jumeg_filter_base
-#from . import jumeg_filter_bw
-#from . import jumeg_filter_ws
-#from . import jumeg_filter_mne

--- a/glassbrain.py
+++ b/glassbrain.py
@@ -15,6 +15,13 @@ labels = ['MFG','AG','MTG','PCC','MPFC']
 brain.add_coords(coords, color='green', labels=labels, scale_factor=1)
 brain.add_arrow(coords[:2,:], color='red')
 mlab.view(45,135)
+
+# Note: If used in a jumeg module, use this below import statements.
+# try:
+#     import glassbrain
+# except Exception as e:
+#     print ('Unable to import glassbrain check mayavi and pysurfer config.')
+
 '''
 
 import numpy as np
@@ -24,7 +31,6 @@ from mayavi import mlab
 from mayavi.mlab import pipeline as mp
 
 import surfer
-from surfer import utils
 
 class ConnecBrain(surfer.Brain):
     """
@@ -88,10 +94,10 @@ class ConnecBrain(surfer.Brain):
             foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
             foci_coords = self.geo[hemi].coords[foci_vtxs]
         else:
-            foci_surf = utils.Surface(self.subject_id, hemi, map_surface,
+            foci_surf = surfer.utils.Surface(self.subject_id, hemi, map_surface,
                                    subjects_dir=self.subjects_dir)
             foci_surf.load_geometry()
-            foci_vtxs = utils.find_closest_vertices(foci_surf.coords, coords)
+            foci_vtxs = surfer.utils.find_closest_vertices(foci_surf.coords, coords)
             foci_coords = self.geo[hemi].coords[foci_vtxs]
 
         # Convert the color code
@@ -163,16 +169,14 @@ class ConnecBrain(surfer.Brain):
             foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
             foci_coords = self.geo[hemi].coords[foci_vtxs]
         else:
-            foci_surf = utils.Surface(self.subject_id, hemi, map_surface,
+            foci_surf = surfer.utils.Surface(self.subject_id, hemi, map_surface,
                                    subjects_dir=self.subjects_dir)
             foci_surf.load_geometry()
-            foci_vtxs = utils.find_closest_vertices(foci_surf.coords, coords)
+            foci_vtxs = surfer.utils.find_closest_vertices(foci_surf.coords, coords)
             foci_coords = self.geo[hemi].coords[foci_vtxs]
-
 
         # foci_vtxs = surfer.utils.find_closest_vertices(self.geo[hemi].coords, coords)
         # foci_coords = self.geo[hemi].coords[foci_vtxs]
-
 
         # Convert the color code
         if not isinstance(color, tuple):
@@ -214,4 +218,3 @@ class ConnecBrain(surfer.Brain):
         self.arrows_dict[name] = al
 
         self._toggle_render(True, views)
-

--- a/jumeg_4raw_data_noise_reducer.py
+++ b/jumeg_4raw_data_noise_reducer.py
@@ -3,7 +3,7 @@
 --- jumeg.jumeg_4raw_data_noise_reducer
 --- modified by FB
 ----> interface for use of only one raw obj or one fif file
-----> use most jumeg_base cls functions  
+----> use most jumeg_base cls functions
 ----------------------------------------------------------------------
 
 --- !!! featuring the one and olny magic EE <jumeg.jumeg_noise_reducer>
@@ -51,19 +51,19 @@ jumeg_noise_reducer.noise_reducer(fname_raw)
 #
 # License: BSD (3-clause)
 
+import os
 import numpy as np
 import time
 import copy
 import warnings
 
-import os
 from math import floor, ceil
 import mne
 from mne.utils import logger
 from mne.epochs import _is_good
 from mne.io.pick import channel_indices_by_type
-from jumeg.jumeg_utils import get_files_from_list
-from jumeg.jumeg_base  import jumeg_base
+from .jumeg_utils import get_files_from_list
+from .jumeg_base import jumeg_base
 
 TINY = 1.e-38
 SVD_RELCUTOFF = 1.e-08
@@ -254,11 +254,11 @@ def perform_detrending(fname_raw,raw=None,save=True):
 
     from mne.io import Raw
     from numpy import poly1d, polyfit
-    
+
     raw = jumeg_base.get_raw_obj(fname_raw,raw=raw)
   # get channels
     picks = jumeg_base.pick_meg_and_ref_nobads()
-    
+
     xval  = np.arange(raw._data.shape[1])
   # loop over all channels
     for ipick in picks:
@@ -328,14 +328,14 @@ def channel_indices_from_list(fulllist, findlist, excllist=None):
 def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending=None,
                   tmin=None,tmax=None,reflp=None,refhp=None,refnotch=None,
                   exclude_artifacts=True,checkresults=True,
-                  fif_extention="-raw.fif",fif_postfix="nr",                        
+                  fif_extention="-raw.fif",fif_postfix="nr",
                   reject={'grad':4000e-13,'mag':4e-12,'eeg':40e-6,'eog':250e-6},
                   complementary_signal=False,fnout=None,verbose=False,save=True):
 
     """Apply noise reduction to signal channels using reference channels.
-        
+
        !!! ONLY ONE RAW Obj Interface Version FB !!!
-           
+
     Parameters
     ----------
     fname_raw : rawfile name
@@ -367,13 +367,13 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
                            (can be useful for debugging)
     checkresults : boolean to control internal checks and overall success [True]
 
-    reject =  dict for rejection threshold 
+    reject =  dict for rejection threshold
               units:
               grad:    T / m (gradiometers)
               mag:     T (magnetometers)
               eeg/eog: uV (EEG channels)
               default=>{'grad':4000e-13,'mag':4e-12,'eeg':40e-6,'eog':250e-6}
-              
+
     save : save data to fif file
 
     Outputfile:
@@ -398,11 +398,11 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
         raise ValueError("Argument complementary_signal must be of type bool")
 
     raw,fname_raw = jumeg_base.get_raw_obj(fname_raw,raw=raw)
-    
-    
+
+
     if detrending:
        raw = perform_detrending(None,raw=raw, save=False)
-    
+
     tc1 = time.clock()
     tw1 = time.time()
 
@@ -443,8 +443,8 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
         # incl. ECG or powerline monitor.
         if verbose:
             print ">>> Using all refchans."
-            
-        refexclude = "bads"      
+
+        refexclude = "bads"
         refpick = jumeg_base.pick_ref_nobads(raw)
     else:
         refpick = channel_indices_from_list(raw.info['ch_names'][:], noiseref,
@@ -513,9 +513,9 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
     # _is_good() from mne-0.9.git-py2.7.egg/mne/epochs.py seems to
     # ignore ref-channels (not covered by dict) and checks individual
     # data segments - artifacts across a buffer boundary are not found.
-    
-    #--- !!! FB put to kwargs    
-    
+
+    #--- !!! FB put to kwargs
+
     #reject = dict(grad=4000e-13, # T / m (gradiometers)
     #              mag=4e-12,     # T (magnetometers)
     #              eeg=40e-6,     # uV (EEG channels)
@@ -698,7 +698,7 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
         sigmean /= n_samples
         sscovdata -= n_samples * sigmean[:] * sigmean[:]
         sscovdata /= (n_samples - 1)
-        
+
         if verbose:
             print ">>> no channel got worse: ", np.all(np.less_equal(sscovdata, sscovinit))
             print ">>> final rt(avg sig pwr) = %12.5e" % np.sqrt(np.mean(sscovdata))
@@ -709,19 +709,19 @@ def noise_reducer_4raw_data(fname_raw,raw=None,signals=[],noiseref=[],detrending
             print ">>> signal covar-calc took %.1f ms (%.2f s walltime)" % (1000. * (tc1 - tct), (tw1 - twt))
             print ">>>"
 
-   #--- fb update 21.07.2015     
-    fname_out = jumeg_base.get_fif_name(raw=raw,postfix=fif_postfix,extention=fif_extention)                       
-      
-    if save:    
+   #--- fb update 21.07.2015
+    fname_out = jumeg_base.get_fif_name(raw=raw,postfix=fif_postfix,extention=fif_extention)
+
+    if save:
        jumeg_base.apply_save_mne_data(raw,fname=fname_out,overwrite=True)
-     
-             
+
+
     tc1 = time.clock()
     tw1 = time.time()
     if verbose:
        print ">>> Total run took %.1f ms (%.2f s walltime)" % (1000. * (tc1 - tc0), (tw1 - tw0))
-        
-    return raw,fname_out  
+
+    return raw,fname_out
 
 ##################################################
 #

--- a/jumeg_4raw_data_plot.py
+++ b/jumeg_4raw_data_plot.py
@@ -4,132 +4,132 @@ Created on Wed Jul 29 16:10:28 2015
 
 @author: fboers
 """
+
 import os.path
 from distutils.dir_util import mkpath
-
 import numpy as np
-import matplotlib.pylab as pl
 import mne
-
-from jumeg.jumeg_base import JuMEG_Base
+from .jumeg_base import JuMEG_Base
 
 
 class JuMEG_Plot(JuMEG_Base):
     def __init__ (self,raw=None):
         super(JuMEG_Plot, self).__init__()
         self.raw = raw
-    
+
         self.dpi = 100
         self.file_extention = '.png'
-    
+
     def minmax(self,d):
         ymin, ymax = d.min(),d.max()
         ymin -= np.abs(ymin) * 0.1 #factor * 1.1
         ymax += np.abs(ymax) * 0.1 #factor * 1.1
-      
+
         return ymin,ymax
-        
+
     def plot_evoked(self,ep,fname=None,save_plot=True,show_plot=False,condition=None,plot_dir=None,
                     info={'meg':{'scale':1e15,'unit':'fT'},'eeg':{'scale':1e3,'unit':'mV'}}):
         '''
-        plot subplots evoked/average 
+        plot subplots evoked/average
         MEG
-        ECG/EOG + performance 
+        ECG/EOG + performance
         STIM Trigger/Response
-        events, rt mean median min max        
+        events, rt mean median min max
         '''
+        import matplotlib.pylab as pl
+
         name = 'test'
-        
+
         if fname:
            fout_path = os.path.dirname(fname)
            name      = os.path.splitext( os.path.basename(fname) )[0]
         else:
            name      = "test.png"
            fout_path = "."
-       
+
         if plot_dir:
            fout_path += "/" + plot_dir
-           mkpath( fout_path )        
-        fout =fout_path +'/'+ name   
-           
+           mkpath( fout_path )
+        fout =fout_path +'/'+ name
+
         #pl.ioff()  # switch  off (interactive) plot visualisation
         pl.figure(name)
         pl.clf()
         #fig = pl.figure(name,figsize=(10, 8), dpi=100))
-        
+
         pl.title(name)
        #--- meg
         pl.subplot(311)
         picks = self.pick_meg_nobads(ep)
-        avg   = ep.average(picks=picks) 
+        avg   = ep.average(picks=picks)
         avg.data *= info['meg']['scale']
-        t0,t1=avg.times.min(), avg.times.max() 
-        
+        t0,t1=avg.times.min(), avg.times.max()
+
         pl.ylim(self.minmax(avg.data))
         pl.xlim(t0,t1)
-         
+
         #pl.xlabel('[s]')
         pl.ylabel('['+ info['meg']['unit']+ ']')
-        
+
         t='Evoked '
         if condition:
            t +=' '+condition
-        if ep.info['bads']:         
+        if ep.info['bads']:
            s = ','. join( ep.info['bads'] )
            pl.title(t +' bads: ' + s)
         else:
            pl.title(t)
-       
+
         pl.grid(True)
         pl.plot(avg.times, avg.data.T,color='black')
-         
-       #--- ecg eog        
+
+       #--- ecg eog
         pl.subplot(312)
         picks  = self.pick_ecg_eog(ep)
         labels =[ ep.info['ch_names'][x] for x in picks]
-        avg    = ep.average(picks=picks) 
+        avg    = ep.average(picks=picks)
         avg.data *= info['eeg']['scale']
         pl.ylim(self.minmax(avg.data))
         pl.xlim(t0,t1)
         pl.ylabel('['+ info['eeg']['unit']+ ']')
-        
+
         pl.grid(True)
         d = pl.plot(avg.times, avg.data.T)
         pl.legend(d, labels, loc=2,prop={'size':8})
-    
-       #--- stim        
+
+       #--- stim
         pl.subplot(313)
-        picks = self.pick_stim_response(ep) 
-        labels =[ ep.info['ch_names'][x] for x in picks]    
-        labels[0] += '  Evts: %d Id: %d' %(ep.events.shape[0],ep.events[0,2]) 
-        avg   = ep.average(picks=picks) 
+        picks = self.pick_stim_response(ep)
+        labels =[ ep.info['ch_names'][x] for x in picks]
+        labels[0] += '  Evts: %d Id: %d' %(ep.events.shape[0],ep.events[0,2])
+        avg   = ep.average(picks=picks)
         pl.ylim(self.minmax(avg.data))
         pl.xlim(t0,t1)
         pl.xlabel('[s]')
-      
+
         pl.grid(True)
         d = pl.plot(avg.times, avg.data.T)
-        pl.legend(d, labels, loc=2,prop={'size':8},)            
-              
+        pl.legend(d, labels, loc=2,prop={'size':8},)
+
        #---
         if save_plot:
-           fout += self.file_extention              
+           fout += self.file_extention
            pl.savefig(fout, dpi=self.dpi)
            if self.verbose:
-              print"---> done saving plot: " +fout 
+              print"---> done saving plot: " +fout
         else:
            fout= "no plot saved"
        #---
         if show_plot:
            pl.show()
-        else:   
-           pl.close()            
-         
+        else:
+           pl.close()
+
         return fout
 
 #TODO
-# ck units ep.info['chs']['unit']  -> 107 
-# call mne.io.constant.FIFF 
+# ck units ep.info['chs']['unit']  -> 107
+# call mne.io.constant.FIFF
 # returns 'FIFF_UNIT_V': 107,
 
 jumeg_4raw_data_plot = JuMEG_Plot()

--- a/jumeg_4raw_data_preproc.py
+++ b/jumeg_4raw_data_preproc.py
@@ -1,7 +1,7 @@
 #import os
 import mne
 
-from jumeg.jumeg_base  import jumeg_base
+from .jumeg_base import jumeg_base
 
 
 #################################################################
@@ -20,11 +20,11 @@ def apply_epocher_events_data(fname,raw=None,condition_list=None,do_run=False,**
 
     """
     from jumeg.epocher.jumeg_epocher  import jumeg_epocher
- 
+
     if do_run :
-                
+
        return jumeg_epocher.apply_events_to_hdf(fname,raw=raw,condition_list=condition_list, **kwargs)
-   
+
 
 
 #######################################################
@@ -38,13 +38,13 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
 
     Parameters
     ----------
-    fname : string 
+    fname : string
         containing the filename of the empty room file (must be a fif-file)
     do_filter: bool
         If true, the empy room file is filtered before calculating
         the covariance matrix. (Beware, filter settings are fixed.)
     filter_parameter: dict
-        dict with filter parameter and flags 
+        dict with filter parameter and flags
     do_run: bool
         execute this
     save: bool
@@ -53,11 +53,11 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
         If not None, override default verbose level
         (see mne.verbose).
         default: verbose=None
-        
+
     RETURN
     ---------
     full empty room filname as string
-    raw obj of input raw-obj or raw-empty-room obj    
+    raw obj of input raw-obj or raw-empty-room obj
     '''
 
     # -------------------------------------------
@@ -65,7 +65,7 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
     # -------------------------------------------
     from mne import compute_raw_data_covariance as cp_covariance
     from mne import write_cov
-    
+
     mne.verbose = verbose
 
     try:
@@ -76,25 +76,25 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
     if raw_empty :
    #--- picks meg channels
        filter_parameter.picks = jumeg_base.pick_meg_nobads(raw_empty)
-  
+
    #--- filter or get filter name
        filter_parameter.do_run = do_filter
 
        if do_filter :
           print "Filtering empty room fif with noise variance settings...\n"
           (fname_empty_room,raw_empty) = apply_filter_data(fname_empty_room,raw=raw_empty,**filter_parameter)
-    
+
 
    #--- update file name for saving noise_cov
     fname_empty_room_cov = fname_empty_room.split('-')[0] + ',empty-cov.fif'
-  
+
    #--- calc nois-covariance matrix
     if do_run :
        noise_cov_mat = cp_covariance(raw_empty,picks=filter_parameter.picks,verbose=verbose)
    #--- write noise-covariance matrix to disk
        if save :
           write_cov( fname_empty_room_cov, noise_cov_mat)
-    
+
     return fname_empty_room_cov
 
 
@@ -119,13 +119,13 @@ def apply_noise_reducer_data(fname,raw=None,do_run=True,verbose=False,save=True,
 
     fname_out = None
     nr_done   = False
-    
-    if do_run :  
+
+    if do_run :
        raw,fname_raw = jumeg_base.get_raw_obj(fname,raw=raw)
        fname_out = jumeg_base.get_fif_name(raw=raw,postfix=fif_postfix,extention=fif_extention,update_raw_fname=False)
-     
+
 #--- apply noise reducer for 50 Hz (and harmonics)
-     
+
        if (reflp or refhp):
           raw,fname_out = noise_reducer_4raw_data(fname,raw=raw,reflp=reflp,refhp=refhp,verbose=verbose,save=False,**kwargs['parameter'])
           kwargs['parameter']['detrending'] = None
@@ -135,15 +135,15 @@ def apply_noise_reducer_data(fname,raw=None,do_run=True,verbose=False,save=True,
               raw,fname_out = noise_reducer_4raw_data(None,raw=raw,refnotch=refn,verbose=verbose,save=False,**kwargs['parameter'])
               kwargs['parameter']['detrending'] = None
           nr_done = True
-  
-     
+
+
        # raw.info['filename'] = fname_out
-       
+
        if not nr_done :
           return fname_raw,raw
-  
+
        raw.info['filename'] = fname_out
-       
+
        if save:
           fname_out = jumeg_base.apply_save_mne_data(raw,fname=fname_out)
 
@@ -177,27 +177,27 @@ def apply_noise_reducer_data(fname,raw=None,do_run=True,verbose=False,save=True,
 def apply_filter_data(fname,raw=None,filter_method="mne",filter_type='bp',fcut1=1.0,fcut2=45.0,notch=None,notch_max=None,order=4,
                       remove_dcoffset = False,njobs=1,overwrite = False,do_run=True,verbose=False,save=True,picks=None,
                       fif_postfix=None, fif_extention='-raw.fif'):
-    ''' 
-    Applies the FIR FFT filter [bp,hp,lp,notches] to data array. 
+    '''
+    Applies the FIR FFT filter [bp,hp,lp,notches] to data array.
     filter_method : mne => fft mne-filter
                     bw  => fft butterwoth
-                    ws  => fft - windowed sinc 
+                    ws  => fft - windowed sinc
     '''
-            
-    from jumeg.filter import jumeg_filter
-   
- #--- define filter 
-    jfilter = jumeg_filter(filter_method=filter_method,filter_type=filter_type,fcut1=fcut1,fcut2=fcut2,njobs=njobs, 
-                                remove_dcoffset=True,order=order)
-    jfilter.verbose = verbose                     
 
-    
+    from jumeg.filter import jumeg_filter
+
+ #--- define filter
+    jfilter = jumeg_filter(filter_method=filter_method,filter_type=filter_type,fcut1=fcut1,fcut2=fcut2,njobs=njobs,
+                                remove_dcoffset=True,order=order)
+    jfilter.verbose = verbose
+
+
     if do_run :
        raw,fname = jumeg_base.get_raw_obj(fname,raw=raw)
-      
+
        if picks is None :
           picks = jumeg_base.pick_channels_nobads(raw)
-          
+
     #- apply filter for picks, exclude stim,resp,bads
        jfilter.sampling_frequency = raw.info['sfreq']
     #--- calc notch array 50,100,150 .. max
@@ -349,7 +349,7 @@ def apply_ica_data(fname,raw=None,do_run=False,verbose=False,save=True,fif_exten
 
     if do_run :
        raw,fname = jumeg_base.get_raw_obj(fname,raw=raw)
-      
+
        from mne.preprocessing import ICA
        picks = jumeg_base.pick_meg_nobads(raw)
 
@@ -475,12 +475,12 @@ def apply_ctps_brain_responses_cleaning_data(fname,raw=None,fname_ica=None,ica_r
 #
 #######################################################
 def apply_epocher_export_events_data(fname,raw=None,condition_list=None,**kwargv):
- 
+
     '''
     apply_export_events
-    
+
     fname,raw=None,condition_list=None,do_run=False,verbose=False,save=False
-     
+
     "events": {
           "template_name":"InKomp",
           "event_extention": ".eve",

--- a/jumeg_math.py
+++ b/jumeg_math.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 ##################################################
 #
 # Function to rescale data

--- a/jumeg_noise_reducer.py
+++ b/jumeg_noise_reducer.py
@@ -46,18 +46,18 @@ jumeg_noise_reducer.noise_reducer(fname_raw)
 #
 # License: BSD (3-clause)
 
+import os
 import numpy as np
 import time
 import copy
 import warnings
-
-import os
 from math import floor, ceil
+
 import mne
 from mne.utils import logger
 from mne.epochs import _is_good
 from mne.io.pick import channel_indices_by_type
-from jumeg.jumeg_utils import get_files_from_list
+from .jumeg_utils import get_files_from_list
 
 TINY = 1.e-38
 SVD_RELCUTOFF = 1.e-08

--- a/jumeg_plot.py
+++ b/jumeg_plot.py
@@ -3,21 +3,13 @@ Plotting functions for jumeg.
 '''
 import os
 import numpy as np
-import matplotlib.pylab as pl
-import matplotlib.ticker as ticker
 import mne
-from mpl_toolkits.axes_grid import make_axes_locatable
-from jumeg.jumeg_utils import (get_files_from_list, thresholded_arr,
-                               triu_indices)
-from jumeg.jumeg_base import jumeg_base
-from jumeg.jumeg_utils import check_read_raw
-from jumeg_math import (calc_performance,
-                        calc_frequency_correlation)
 
-try:
-    import glassbrain
-except Exception as e:
-    print ('Unable to import glassbrain check mayavi and pysurfer config.')
+from .jumeg_utils import (get_files_from_list, thresholded_arr,
+                               triu_indices, check_read_raw)
+from .jumeg_base import jumeg_base
+from .jumeg_math import (calc_performance,
+                         calc_frequency_correlation)
 
 
 def plot_powerspectrum(fname, raw=None, picks=None, dir_plots="plots",
@@ -25,9 +17,7 @@ def plot_powerspectrum(fname, raw=None, picks=None, dir_plots="plots",
         '''
 
         '''
-        import os
         import matplotlib.pyplot as pl
-        import mne
         from distutils.dir_util import mkpath
 
         if raw is None:
@@ -64,6 +54,7 @@ def plot_average(filenames, save_plot=True, show_plot=False, dpi=100):
 
     fname = get_files_from_list(filenames)
 
+    import matplotlib.pyplot as pl
     # plot averages
     pl.ioff()  # switch off (interactive) plot visualisation
     factor = 1e15
@@ -100,6 +91,7 @@ def plot_performance_artifact_rejection(meg_raw, ica, fnout_fig,
     and after the cleaning process.
     '''
 
+    import matplotlib.pyplot as pl
     from mne.preprocessing import find_ecg_events, find_eog_events
     from jumeg import jumeg_math as jmath
 
@@ -264,6 +256,7 @@ def plot_compare_brain_responses(fname_orig, fname_new, event_id=1,
     show: bool (default False)
     '''
 
+    import matplotlib.pyplot as pl
     pl.ioff()
     if show:
         pl.ion()
@@ -353,7 +346,7 @@ def plot_compare_brain_responses(fname_orig, fname_new, event_id=1,
 #
 ###########################################################
 def drawmatrix_channels(in_m, channel_names=None, fig=None, x_tick_rot=0,
-                        size=None, cmap=pl.cm.RdBu_r, colorbar=True,
+                        size=None, cmap=None, colorbar=True,
                         color_anchor=None, title=None):
     r"""Creates a lower-triangle of the matrix of an nxn set of values. This is
     the typical format to show a symmetrical bivariate quantity (such as
@@ -386,12 +379,19 @@ def drawmatrix_channels(in_m, channel_names=None, fig=None, x_tick_rot=0,
     fig: a figure object
 
     """
+    import matplotlib.ticker as ticker
+    from mpl_toolkits.axes_grid import make_axes_locatable
+
     N = in_m.shape[0]
     ind = np.arange(N)  # the evenly spaced plot indices
 
     def channel_formatter(x, pos=None):
         thisind = np.clip(int(x), 0, N - 1)
         return channel_names[thisind]
+
+    if cmap is None:
+        from matplotlib.pyplot import cm
+        cmap = cm.RdBu_r
 
     if fig is None:
         fig = pl.figure()
@@ -502,6 +502,7 @@ def drawmatrix_channels(in_m, channel_names=None, fig=None, x_tick_rot=0,
 def draw_matrix(mat, th1=None, th2=None, clim=None, cmap=None):
     """Draw a matrix, optionally thresholding it.
     """
+    import matplotlib.pyplot as pl
     if th1 is not None:
         m2 = thresholded_arr(mat, th1, th2)
     else:
@@ -584,6 +585,7 @@ def plot_artefact_overview(raw_orig, raw_clean, stim_event_ids=[1],
         is always in femtoTesla (fT) (1e15)
     '''
 
+    import matplotlib.pyplot as pl
     from mne.preprocessing import create_ecg_epochs, create_eog_epochs
 
     raw = check_read_raw(raw_orig, preload=True)

--- a/jumeg_preproc_data.py
+++ b/jumeg_preproc_data.py
@@ -1,13 +1,6 @@
-#import os
+
 import mne
-
-from jumeg.jumeg_base               import jumeg_base
-
-#from jumeg.decompose.ocarta         import ocarta
-#from jumeg.ctps                     import ctps
-
-#from jumeg import jumeg_plot
-
+from jumeg.jumeg_base import jumeg_base
 
 #################################################################
 #
@@ -52,13 +45,13 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
 
     Parameters
     ----------
-    fname : string 
+    fname : string
         containing the filename of the empty room file (must be a fif-file)
     do_filter: bool
         If true, the empy room file is filtered before calculating
         the covariance matrix. (Beware, filter settings are fixed.)
     filter_parameter: dict
-        dict with filter parameter and flags 
+        dict with filter parameter and flags
     do_run: bool
         execute this
     save: bool
@@ -67,11 +60,11 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
         If not None, override default verbose level
         (see mne.verbose).
         default: verbose=None
-        
+
     RETURN
     ---------
     full empty room filname as string
-    raw obj of input raw-obj or raw-empty-room obj    
+    raw obj of input raw-obj or raw-empty-room obj
     '''
 
     # -------------------------------------------
@@ -93,25 +86,25 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
     if raw_empty :
    #--- picks meg channels
        filter_parameter.picks = jumeg_base.pick_meg_nobads(raw_empty)
-  
+
    #--- filter or get filter name
        filter_parameter.do_run = do_filter
 
        if do_filter :
           print "Filtering empty room fif with noise variance settings...\n"
           (fname_empty_room,raw_empty) = apply_filter_data(fname_empty_room,raw=raw_empty,**filter_parameter)
-    
+
 
    #--- update file name for saving noise_cov
     fname_empty_room_cov = fname_empty_room.split('-')[0] + ',empty-cov.fif'
-  
+
    #--- calc nois-covariance matrix
     if do_run :
        noise_cov_mat = cp_covariance(raw_empty,picks=filter_parameter.picks,verbose=verbose)
    #--- write noise-covariance matrix to disk
        if save :
           write_cov( fname_empty_room_cov, noise_cov_mat)
-    
+
     return fname_empty_room_cov
 
 
@@ -123,31 +116,31 @@ def apply_create_noise_covariance_data(fname,raw=None,do_filter=True,filter_para
 def apply_filter_data(fname,raw=None,filter_method="mne",filter_type='bp',fcut1=1.0,fcut2=45.0,notch=None,notch_max=None,order=4,
                       remove_dcoffset = False,njobs=1,overwrite = False,do_run=True,verbose=False,save=True,picks=None,
                       fif_postfix=None, fif_extention='-raw.fif'):
-    ''' 
-    Applies the FIR FFT filter [bp,hp,lp,notches] to data array. 
+    '''
+    Applies the FIR FFT filter [bp,hp,lp,notches] to data array.
     filter_method : mne => fft mne-filter
                     bw  => fft butterwoth
-                    ws  => fft - windowed sinc 
+                    ws  => fft - windowed sinc
     '''
-            
+
     from jumeg.filter import jumeg_filter
-   
- #--- define filter 
-    jfilter = jumeg_filter(filter_method=filter_method,filter_type=filter_type,fcut1=fcut1,fcut2=fcut2,njobs=njobs, 
+
+ #--- define filter
+    jfilter = jumeg_filter(filter_method=filter_method,filter_type=filter_type,fcut1=fcut1,fcut2=fcut2,njobs=njobs,
                                 remove_dcoffset=True,order=order)
-    jfilter.verbose = verbose                     
+    jfilter.verbose = verbose
 
     if do_run :
        if raw is None:
           if fname is None:
-             print"ERROR no file foumd!!\n" 
-             return 
+             print"ERROR no file foumd!!\n"
+             return
           raw = mne.io.Raw(fname,preload=True)
           print"\n"
 
        if picks is None :
           picks = jumeg_base.pick_channels_nobads(raw)
-          
+
     #- apply filter for picks, exclude stim,resp,bads
        jfilter.sampling_frequency = raw.info['sfreq']
     #--- calc notch array 50,100,150 .. max
@@ -424,4 +417,3 @@ def apply_ctps_brain_responses_cleaning_data(fname,raw=None,fname_ica=None,ica_r
     print "===> Done JuMEG MNE ICA clean: " + fhdf
 
     return fhdf
-

--- a/jumeg_preprocessing.py
+++ b/jumeg_preprocessing.py
@@ -2,11 +2,10 @@
 
 import os
 import numpy as np
-import matplotlib.pyplot as pl
 import mne
 from mne.preprocessing import ctps_ as ctps
-from jumeg_utils import get_files_from_list
-from jumeg_plot import (plot_average, plot_performance_artifact_rejection,
+from .jumeg_utils import get_files_from_list
+from .jumeg_plot import (plot_average, plot_performance_artifact_rejection,
                               plot_compare_brain_responses)
 
 
@@ -744,6 +743,7 @@ def apply_ctps_select_ic(fname_ctps, threshold=0.1):
 
     fnlist = get_files_from_list(fname_ctps)
 
+    import matplotlib.pyplot as pl
     # loop across all filenames
     pl.ioff()  # switch off (interactive) plot visualisation
     ifile = 0

--- a/jumeg_source_localize.py
+++ b/jumeg_source_localize.py
@@ -7,7 +7,7 @@
 import os
 import sys
 from mne import setup_source_space
-from jumeg_utils import (get_files_from_list, check_env_variables,
+from .jumeg_utils import (get_files_from_list, check_env_variables,
                          retcode_error)
 
 # using subprocess to run freesurfer commands (other option os.system)

--- a/jumeg_suggest_bads.py
+++ b/jumeg_suggest_bads.py
@@ -11,10 +11,9 @@ authors: Niko Kampel, n.kampel@gmail.com
 
 import numpy as np
 import mne
-import matplotlib.pyplot as plt
 from sklearn.cluster import DBSCAN
 from sklearn.metrics.pairwise import euclidean_distances
-from jumeg.jumeg_utils import check_read_raw
+from .jumeg_utils import check_read_raw
 
 
 def compute_euclidean_stats(epoch, sensitivity, mode='adaptive',
@@ -253,6 +252,7 @@ def plot_autosuggest_summary(afp_nearest_neighbour, psd_nearest_neighbour,
 
     #TODO Improve documentation.
     '''
+    import matplotlib.pyplot as plt
     plt.style.use(['seaborn-deep'])
 
     # calculate data for summary_plot
@@ -333,6 +333,7 @@ def old_summary_plot():
 
     kept here only for archival purposes
     '''
+    import matplotlib.pyplot as plt
     summary_plot = plt.figure()
     plt.subplots_adjust(hspace=0)
     t = np.arange(len(minimap[1]))

--- a/jumeg_utils.py
+++ b/jumeg_utils.py
@@ -13,11 +13,11 @@ import os
 import os.path as op
 import numpy as np
 import scipy as sci
+from sklearn.utils import check_random_state
+
 import mne
 from mne.utils import logger
-import matplotlib.cm as cmx
-import matplotlib.colors as colors
-from sklearn.utils import check_random_state
+
 
 def get_files_from_list(fin):
     ''' Return string of file or files as iterables lists '''
@@ -1314,6 +1314,8 @@ def convert_label2label(annot_fname, subjects_list, srcsubject='fsaverage',
 def get_cmap(N):
     '''Returns a function that maps each index in 0, 1, ... N-1 to a distinct
     RGB color.'''
+    import matplotlib.cm as cmx
+    import matplotlib.colors as colors
     color_norm = colors.Normalize(vmin=0, vmax=N-1)
     scalar_map = cmx.ScalarMappable(norm=color_norm, cmap='hsv')
 

--- a/mft/__init__.py
+++ b/mft/__init__.py
@@ -2,11 +2,11 @@
 #
 # License: Simplified BSD
 
-from jumeg_mft_funcs import (apply_mft, calc_cdm_w_cut,
-                             compare_est_exp, fit_cdm_w_cut,
-                             scan_cdm_w_cut)
-from jumeg_mft_plot import (plot_cdm_data, plot_cdv_distribution,
-                            plot_cdvsum_data, 
-                            plot_global_cdv_dist, plot_max_amplitude_data,
-                            plot_max_cdv_data, plot_quality_data,
-                            plot_visualize_mft_sources)
+from .jumeg_mft_funcs import (apply_mft, calc_cdm_w_cut,
+                              compare_est_exp, fit_cdm_w_cut,
+                              scan_cdm_w_cut)
+from .jumeg_mft_plot import (plot_cdm_data, plot_cdv_distribution,
+                             plot_cdvsum_data,
+                             plot_global_cdv_dist, plot_max_amplitude_data,
+                             plot_max_cdv_data, plot_quality_data,
+                             plot_visualize_mft_sources)

--- a/mft/jumeg_mft_plot.py
+++ b/mft/jumeg_mft_plot.py
@@ -5,11 +5,11 @@ Jumeg MFT Plotting.
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
 import warnings
 
-from nilearn.plotting import plot_stat_map
-from nilearn.image import index_img
+# the below imports are unnecessary
+# from nilearn.plotting import plot_stat_map
+# from nilearn.image import index_img
 
 from mne import SourceEstimate, VolSourceEstimate
 from mne.transforms import invert_transform, apply_trans
@@ -22,6 +22,7 @@ def plot_global_cdv_dist(stcdata,fwdmag=None):
     stcdata: stc with ||cdv|| (point sequence as in fwdmag['source_rr'])
     fwdmag:  (opt) forward solution (to colorize srcs)
     '''
+    import matplotlib.pyplot as plt
     print "##### Plot global cdv-distribution at time of max |cdv|:"
     time_idx = np.argmax(np.max(stcdata, axis=0))
     fig = plt.figure()
@@ -58,6 +59,7 @@ def plot_visualize_mft_sources(fwdmag, stcdata, tmin, tstep,
     stcdata: stc with ||cdv|| (point sequence as in fwdmag['source_rr'])
     tmin, tstep, subject: passed to mne.SourceEstimate()
     '''
+    import matplotlib.pyplot as plt
     print "##### Attempting to plot:"
     # cf. decoding/plot_decoding_spatio_temporal_source.py
     vertices = [s['vertno'] for s in fwdmag['src']]
@@ -118,7 +120,7 @@ def plot_visualize_mft_sources(fwdmag, stcdata, tmin, tstep,
             mrfoci = apply_trans(invmri_head_t['trans'],cfoci, move=True)
             print "mrfoci: "
             print mrfoci
-    
+
             # Just some blops along the coordinate axis:
             # This will not yield reasonable results w an inflated brain.
             #bloblist = np.zeros((300,3))
@@ -140,6 +142,7 @@ def plot_cdv_distribution(fwdmag, stcdata):
     fwdmag:  forward solution
     stcdata: stc with ||cdv|| (point sequence as in fwdmag['source_rr'])
     '''
+    import matplotlib.pyplot as plt
     print "##### Plot cdv-distribution:"
     maxxpnt = np.max([len(s['vertno']) for s in fwdmag['src']])
     time_idx = np.argmax(np.max(stcdata, axis=0))
@@ -171,6 +174,7 @@ def plot_max_amplitude_data(fwdmag, stcdata, tmin, tstep, subject, method='mft')
     tmin, tstep, subject: passed to mne.VolSourceEstimate()
     method: used as y-axis label
     '''
+    import matplotlib.pyplot as plt
     print "##### Attempting to plot max. amplitude data:"
     fig = plt.figure()
     offsets = [0]
@@ -199,6 +203,7 @@ def plot_max_cdv_data(stc_mft, lhmrinds, rhmrinds):
     ----------
     stcdata: stc with ||cdv|| (point sequence as in fwdmag['source_rr'])
     '''
+    import matplotlib.pyplot as plt
     print "##### Attempting to plot max. cdv data:"
     fig = plt.figure()
     stcdata = stc_mft.data
@@ -215,6 +220,7 @@ def plot_max_cdv_data(stc_mft, lhmrinds, rhmrinds):
 def plot_cdvsum_data(stc_mft, lhmrinds, rhmrinds):
     '''Plot cdvsum data.
     '''
+    import matplotlib.pyplot as plt
     print "##### Attempting to cdvsum data:"
     fig = plt.figure()
     stcdata = stc_mft.data
@@ -231,6 +237,7 @@ def plot_cdvsum_data(stc_mft, lhmrinds, rhmrinds):
 def plot_quality_data(qualmft, stc_mft):
     '''Plot quality data.
     '''
+    import matplotlib.pyplot as plt
     print "##### Attempting to plot quality data:"
     fig = plt.figure()
     # relerrscal = pow(10,-int(np.log10(np.max(qualmft['relerr'][:]))))
@@ -252,6 +259,7 @@ def plot_quality_data(qualmft, stc_mft):
 def plot_cdm_data(qualmft,stc_mft, cdmlabels=None, outfile=None):
     '''Plot CDM data.
     '''
+    import matplotlib.pyplot as plt
     if cdmlabels is not None and qualmft.has_key('cdmlabels'):
         print "##### Attempting to plot cdm data for labels:"
         fig = plt.figure()
@@ -316,6 +324,7 @@ def plot_cdm_data(qualmft,stc_mft, cdmlabels=None, outfile=None):
 def plot_jlong_data(qualmft,stc_mft, outfile=None):
     '''Plot jlong label data.
     '''
+    import matplotlib.pyplot as plt
     if not qualmft.has_key('jlgall') and not qualmft.has_key('jlgright') and \
        not qualmft.has_key('jlgleft'):
         return
@@ -341,6 +350,7 @@ def plot_jlong_data(qualmft,stc_mft, outfile=None):
 def plot_jlong_labeldata(qualmft,stc_mft, cdmlabels, outfile=None):
     '''Plot jlong label data.
     '''
+    import matplotlib.pyplot as plt
     if cdmlabels is None or not qualmft.has_key('jlglabels') \
                          or not qualmft.has_key('cdmlabels'):
         return
@@ -386,6 +396,7 @@ def plot_jlong_labeldata(qualmft,stc_mft, cdmlabels, outfile=None):
 def plot_jtotal_labeldata(qualmft,stc_mft, cdmlabels, outfile=None):
     '''Plot jtotal label data.
     '''
+    import matplotlib.pyplot as plt
     if cdmlabels is None or not qualmft.has_key('jtotlabels') \
                          or not qualmft.has_key('cdmlabels'):
         return


### PR DESCRIPTION
The issue where jumeg was taking too long to load has been addressed in this PR. 

- unwanted imports removed
- import are organized organized and matplotlib related imports have been relocated
- time of importing the package has been drastically reduced

**Before:**
psripad@pravmac:~ $time python -c 'import jumeg'
/Users/psripad/miniconda2/lib/python2.7/site-packages/matplotlib/font_manager.py:273: UserWarning: Matplotlib is building the font cache using fc-list. This may take a moment.
  warnings.warn('Matplotlib is building the font cache using fc-list. This may take a moment.')
/Users/psripad/miniconda2/lib/python2.7/site-packages/sklearn/cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)
user	0m7.571s
sys	0m1.821s

**After:**
psripad@pravmac:~ $time python -c 'import jumeg'
user	0m0.678s
sys	0m0.220s

