### PR TITLE
plot_grouped_causality_circle() now plots the strongest connections no matter if in the upper or lower triangle + fixed arrow direction

### DIFF
--- a/examples/connectivity/plot_grouped_connectivity_circle.py
+++ b/examples/connectivity/plot_grouped_connectivity_circle.py
@@ -34,4 +34,5 @@ plot_grouped_connectivity_circle(yaml_fname, con, label_names,
                                  replacer_dict=replacer_dict,
                                  out_fname='example_grouped_con_circle.png',
                                  colorbar_pos=(0.1, 0.1),
-                                 n_lines=10, colorbar=True)
+                                 n_lines=10, colorbar=True,
+                                 colormap='viridis')

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -681,36 +681,17 @@ def plot_generic_grouped_circle(yaml_fname, con, orig_labels,
     assert len(node_order) == node_order_size, 'Node order length is correct.'
 
     # the respective no. of regions in each cortex
-    group_bound = [len(labels[key]) for key in list(labels.keys())]
-    group_bound = [0] + group_bound
-    group_boundaries = [sum(group_bound[:i+1]) for i in range(len(group_bound))]
+    group_numbers = [len(labels[key]) for key in list(labels.keys())]
 
-    # remove the first element of group_bound
-    # make label colours such that each cortex is of one colour
-    group_bound.pop(0)
-    label_colors = []
-    for ind, rep in enumerate(group_bound):
-        label_colors += [cortex_colors[ind]] * rep
-    assert len(label_colors) == len(node_order), 'Number of colours do not match'
-
-    # remove the last total sum of the list
-    group_boundaries.pop()
-
-    from mne.viz.circle import circular_layout
-    node_angles = circular_layout(orig_labels, label_names, start_pos=90,
-                                  group_boundaries=group_boundaries)
-
-    # the order of the node_colors must match that of orig_labels
-    # therefore below reordering is necessary
-    reordered_colors = [label_colors[node_order.index(orig)]
-                        for orig in orig_labels]
+    node_angles, node_colors = _get_node_angles_and_colors(group_numbers, cortex_colors,
+                                                           node_order, orig_labels)
 
     # Plot the graph using node_order and colours
     # orig_labels is the order on nodes in the con matrix (important)
     plot_connectivity_circle(con, orig_labels, n_lines=n_lines,
                              facecolor='white', textcolor='black',
                              node_angles=node_angles,
-                             node_colors=reordered_colors,
+                             node_colors=node_colors,
                              node_edgecolor='white', fig=fig,
                              fontsize_names=8, vmax=vmax, vmin=vmin,
                              colorbar_size=0.2, colorbar_pos=(-0.3, 0.1),

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -766,6 +766,10 @@ def plot_degree_circle(degrees, yaml_fname, orig_labels_fname,
     Given degree values of various nodes of a network, plot a grouped circle
     plot a scatter plot around a circle.
     """
+
+    cortex_colors = ['m', 'b', 'y', 'c', 'r', 'g',
+                     'g', 'r', 'c', 'y', 'b', 'm']
+
     n_nodes = len(degrees)
 
     with open(orig_labels_fname, 'r') as f:
@@ -796,20 +800,11 @@ def plot_degree_circle(degrees, yaml_fname, orig_labels_fname,
 
     # the respective no. of regions in each cortex
     # yaml fix order change
-    group_bound = [len(list(key.values())[0]) for key in labels]
-    group_bound = [0] + group_bound[::-1] + group_bound
-    group_boundaries = [sum(group_bound[:i+1]) for i in range(len(group_bound))]
+    group_numbers = [len(list(key.values())[0]) for key in labels]
+    group_numbers = group_numbers[::-1] + group_numbers
 
-    # remove the first element of group_bound
-    # make label colours such that each cortex is of one colour
-    group_bound.pop(0)
-
-    # remove the last total sum of the list
-    group_boundaries.pop()
-
-    from mne.viz.circle import circular_layout
-    node_angles = circular_layout(orig_labels, node_order, start_pos=90,
-                                  group_boundaries=group_boundaries)
+    node_angles, node_colors = _get_node_angles_and_colors(group_numbers, cortex_colors,
+                                                           node_order, orig_labels)
 
     # prepare group label positions
     group_labels = [list(lab.keys())[0] for lab in labels]
@@ -836,23 +831,10 @@ def plot_degree_circle(degrees, yaml_fname, orig_labels_fname,
 
     ax = plt.subplot(*subplot, polar=True, facecolor='white')
 
-    cortex_colors = ['m', 'b', 'y', 'c', 'r', 'g',
-                     'g', 'r', 'c', 'y', 'b', 'm']
-
-    label_colors = []
-    for ind, rep in enumerate(group_bound):
-        label_colors += [cortex_colors[ind]] * rep
-    assert len(label_colors) == len(node_order), 'Number of colours do not match'
-
-    # the order of the node_colors must match that of orig_labels
-    # therefore below reordering is necessary
-    reordered_colors = [label_colors[node_order.index(orig)]
-                        for orig in orig_labels]
-
     # first plot the circle showing the degree
     theta = np.deg2rad(node_angles)
     radii = np.ones(len(node_angles)) * radsize
-    c = ax.scatter(theta, radii, c=reordered_colors, s=degrees * degsize,
+    c = ax.scatter(theta, radii, c=node_colors, s=degrees * degsize,
                    cmap=None, alpha=alpha)
 
     ax.grid(False)

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -129,7 +129,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                              fontsize_names=8, fontsize_colorbar=8, padding=6.,
                              fig=None, subplot=111, interactive=True,
                              node_linewidth=2., show=True, arrow=False,
-                             arrowstyle='->,head_length=3,head_width=3', **kwargs):
+                             arrowstyle='->,head_length=0.7,head_width=0.4', **kwargs):
     """Visualize connectivity as a circular graph.
 
     Note: This code is based on the circle graph example by Nicolas P. Rougier
@@ -265,6 +265,12 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
         if is_symmetric:
             indices = np.tril_indices(n_nodes, -1)
         else:
+            if not arrow:
+                import warnings
+                warnings.warn('Since the con matrix is asymmetric it will be '
+                              'treated as a causality matrix and arrow will '
+                              'be set to True.', Warning)
+                arrow = True
             # get off-diagonal indices
             indices = np.where(~np.eye(con.shape[0], dtype=bool))
 

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -290,7 +290,14 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
 
     # Draw lines between connected nodes, only draw the strongest connections
     if n_lines is not None and len(con) > n_lines:
-        con_thresh = np.sort(np.abs(con).ravel())[-n_lines]
+
+        n_significant_cons = len(np.where(con)[0])
+
+        if n_significant_cons > n_lines:
+            con_thresh = np.sort(np.abs(con).ravel())[-n_lines]
+        else:
+            con_thresh = np.sort(np.abs(con).ravel())[-n_significant_cons]
+
     else:
         con_thresh = 0.
 

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -624,7 +624,7 @@ def _get_group_node_angles_and_colors(labels, orig_labels, node_order_size, cort
 def _get_node_angles_and_colors(group_numbers, cortex_colors, node_order, orig_labels):
 
     # the respective no. of regions in each cortex
-    group_boundaries = np.cumsum(group_numbers)
+    group_boundaries = np.cumsum([0] + group_numbers)[:-1]
 
     label_colors = []
     for ind, rep in enumerate(group_numbers):
@@ -638,7 +638,7 @@ def _get_node_angles_and_colors(group_numbers, cortex_colors, node_order, orig_l
     node_colors = [label_colors[node_order.index(orig)] for orig in orig_labels]
 
     node_angles = circular_layout(orig_labels, node_order, start_pos=90,
-                                  group_boundaries=group_boundaries[:-1])
+                                  group_boundaries=group_boundaries)
 
     return node_angles, node_colors
 

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -295,6 +295,10 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
 
         if n_significant_cons > n_lines:
             con_thresh = np.sort(np.abs(con).ravel())[-n_lines]
+        elif n_significant_cons == 0:
+            # there are no significant connections, set minimum threshold to
+            # avoid plotting everything
+            con_thresh = 0.001
         else:
             con_thresh = np.sort(np.abs(con).ravel())[-n_significant_cons]
 

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -795,7 +795,7 @@ def plot_grouped_causality_circle(caus, yaml_fname, label_names, n_lines=None,
         # get strongest causal connections in entire causality matrix
         con = con[con[:, 1].argsort()][n_lines:]
         # get how many are in upper and in lower triangle
-        n_liness = [n_lines - con[:, 0].sum(), con[:, 0].sum()]
+        n_liness = [int(n_lines - con[:, 0].sum()), int(con[:, 0].sum())]
     else:
         n_liness = [None, None]
 


### PR DESCRIPTION
Currently plot_grouped_causality_circle() takes the strongest n connections (where n is n_lines) in the upper triangle and the strongest n_connections in the lower triangle for a total of 2n connections.

This ignores the fact that the strongest connections could all be in one of the triangles.

My suggestion takes the strongest n connections in the upper and the strongest n connections in the lower triangle and groups them together while keeping track from which triangle they come from. The strongest n connections are then selected. Separate n_lines are set for plotting the upper and lower triangle connections according to how many of the strongest connections are in the upper or lower triangle. 

n_lines is now the total number of connections that will be plotted instead of half the number of connections.