### PR TITLE
Fix numeric error in running MFT examples.

### DIFF
--- a/examples/mft/plot_perform_mft_surface_list.py
+++ b/examples/mft/plot_perform_mft_surface_list.py
@@ -126,7 +126,7 @@ if write_tab_files:
     tabfile.write("# time_idx = %d\n" % time_idx)
     tabfile.write("# max amplitude = %11.4e\n" % cdvnmax)
     tabfile.write("#  x/mm    y/mm    z/mm     |cdv|   index\n")
-    for ipnt in range(n_loc / 3):
+    for ipnt in range(int(n_loc / 3)):
         copnt = 1000. * fwdmag['source_rr'][ipnt]
         tabfile.write(" %7.2f %7.2f %7.2f %11.4e %5d\n" % \
                       (copnt[0], copnt[1], copnt[2], stcdata[ipnt, time_idx], ipnt))

--- a/jumeg/mft/jumeg_mft_funcs.py
+++ b/jumeg/mft/jumeg_mft_funcs.py
@@ -672,7 +672,7 @@ def apply_mft(fwdspec, dataspec, evocondition=None, meg='mag',
     elif mftparm['prbfct'] == 'flat' or mftparm['prbfct'] == 'uniform':
         if verbosity >= 2:
             print("Setting initial w=const !")
-        wdist0 = np.ones(n_loc / 3) / (float(n_loc) / np.sqrt(3.))
+        wdist0 = np.ones(int(n_loc / 3)) / (float(n_loc) / np.sqrt(3.))
     elif mftparm['prbfct'] == 'random':
         if verbosity >= 2:
             print("Setting initial w=random !")


### PR DESCRIPTION
Fixed the below error that prevented the examples / tests from running:

```
########## Calculate initial prob-dist:
Setting initial w=const !
Traceback (most recent call last):
  File "plot_perform_mft_surface.py", line 73, in <module>
    mftpar=mftpar, verbose='verbose')
  File "/Users/psripad/miniconda3/lib/python3.7/site-packages/jumeg/mft/jumeg_mft_funcs.py", line 675, in apply_mft
    wdist0 = np.ones(n_loc / 3) / (float(n_loc) / np.sqrt(3.))
  File "/Users/psripad/miniconda3/lib/python3.7/site-packages/numpy/core/numeric.py", line 207, in ones
    a = empty(shape, dtype, order)
TypeError: 'float' object cannot be interpreted as an integer
```
