### PR TITLE
Refactoring of plot_grouped_connectivity_circle() in con_viz.py

### DIFF
--- a/examples/connectivity/plot_destriux_atlas_based_connectivity.py
+++ b/examples/connectivity/plot_destriux_atlas_based_connectivity.py
@@ -27,7 +27,6 @@ con[con < 0.5] = 0.
 
 # plot grouped connnectivity
 plot_grouped_connectivity_circle(grouping_yaml_fname, con, label_names,
-                                 labels_mode=None, node_order_size=148,
-                                 colorbar_pos=(0.1, 0.1), replacer_dict=None,
-                                 out_fname='destriux_circle.png',
+                                 labels_mode=None, colorbar_pos=(0.1, 0.1),
+                                 replacer_dict=None, out_fname='destriux_circle.png',
                                  n_lines=50, colorbar=True)

--- a/examples/connectivity/plot_label_distances.py
+++ b/examples/connectivity/plot_label_distances.py
@@ -56,7 +56,7 @@ _, coords, _, _ = get_label_distances(subject, subjects_dir, parc=parc)
 degs = mne.connectivity.degree(con, threshold_prop=1)
 
 # show the label ROIs using Nilearn plotting
-fig = plotting.plot_connectome(np.zeros((node_order_size, node_order_size)),
+fig = plotting.plot_connectome(np.zeros((con.shape[0], con.shape[0])),
                                coords, node_size=20, edge_threshold='99%',
                                node_color='cornflowerblue',
                                display_mode='ortho',

--- a/examples/connectivity/plot_label_distances.py
+++ b/examples/connectivity/plot_label_distances.py
@@ -36,7 +36,6 @@ with open(replacer_dict_fname, 'r') as f:
 
 # load the distances matrix
 con = np.load(label_distances_fname)
-node_order_size = con.shape[0]
 
 # forget long range connections, plot short neighbouring connections
 neighbor_range = 30.  # millimetres 
@@ -44,7 +43,6 @@ con[con > neighbor_range] = 0.
 
 plot_grouped_connectivity_circle(yaml_fname, con, label_names,
                                  labels_mode='cortex_only',
-                                 node_order_size=node_order_size,
                                  replacer_dict=replacer_dict,
                                  out_fname='label_com_distances_circle_%0.1f_%s.png' % (neighbor_range, parc),
                                  colorbar_pos=(0.1, 0.1),

--- a/examples/connectivity/plot_standard_resting_network_on_aparc_annot_map.py
+++ b/examples/connectivity/plot_standard_resting_network_on_aparc_annot_map.py
@@ -97,7 +97,7 @@ con += con.T  # since we only add the combinations
 from matplotlib.colors import ListedColormap
 cmap = ListedColormap(['m', 'k', 'b', 'y', 'r', 'c', 'g'])
 yaml_fname = get_jumeg_path() + '/data/desikan_aparc_cortex_based_grouping.yaml'
+
 plot_grouped_connectivity_circle(yaml_fname, con, aparc_names, n_lines=12,
-                                 labels_mode=None, node_order_size=68,
-                                 colormap=cmap, colorbar=True, replacer_dict=None,
-                                 indices=None, out_fname='rsn_circle_plot.png')
+                                 labels_mode=None, colormap=cmap, colorbar=True,
+                                 replacer_dict=None, indices=None, out_fname='rsn_circle_plot.png')

--- a/jumeg/connectivity/con_viz.py
+++ b/jumeg/connectivity/con_viz.py
@@ -664,9 +664,9 @@ def _get_node_grouping(label_groups, orig_labels):
     node_order_size = len(orig_labels)
 
     label_names = list()
-    for lab in label_groups:
+    for group in label_groups:
         # label_names.extend(labels[lab])
-        label_names += list(lab.values())[0]  # yaml order fix
+        label_names += list(group.values())[0]  # yaml order fix
 
     lh_labels = [name + '-lh' for name in label_names if name + '-lh' in orig_labels]
     rh_labels = [name + '-rh' for name in label_names if name + '-rh' in orig_labels]
@@ -757,7 +757,7 @@ def plot_generic_grouped_circle(yaml_fname, con, orig_labels,
     # read the yaml file with grouping
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:
-            labels = yaml.safe_load(f)
+            label_groups = yaml.safe_load(f)
     else:
         print('%s - File not found.' % yaml_fname)
         sys.exit()
@@ -766,15 +766,15 @@ def plot_generic_grouped_circle(yaml_fname, con, orig_labels,
 
     # make list of label_names (without individual cortex locations)
     label_names = list()
-    for lab in labels:
-        label_names.extend(labels[lab])
+    for group in label_groups:
+        label_names.extend(label_groups[group])
 
     # here label_names are the node_order
     node_order = label_names
     assert len(node_order) == node_order_size, 'Node order length is correct.'
 
     # the respective no. of regions in each cortex
-    group_numbers = [len(labels[key]) for key in list(labels.keys())]
+    group_numbers = [len(label_groups[key]) for key in list(label_groups.keys())]
 
     node_angles, node_colors = _get_node_angles_and_colors(group_numbers, cortex_colors,
                                                            node_order, orig_labels)
@@ -795,7 +795,7 @@ def plot_generic_grouped_circle(yaml_fname, con, orig_labels,
         import matplotlib.patches as mpatches
         legend_patches = [mpatches.Patch(color=col, label=key)
                           for col, key in zip(['g', 'r', 'c', 'y', 'b', 'm'],
-                                              list(labels.keys()))]
+                                              list(label_groups.keys()))]
         pl.legend(handles=legend_patches, loc=(0.02, 0.02), ncol=1,
                   mode=None, fontsize='small')
     if out_fname:
@@ -889,13 +889,13 @@ def plot_degree_circle(degrees, yaml_fname, orig_labels_fname,
     # read the yaml file with grouping of the various nodes
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:
-            labels = yaml.safe_load(f)
+            label_groups = yaml.safe_load(f)
     else:
         print('%s - File not found.' % yaml_fname)
         sys.exit()
 
     # make list of label_names (without individual cortex locations)
-    label_names = [list(lab.values())[0] for lab in labels]
+    label_names = [list(group.values())[0] for group in label_groups]
     label_names = [la for l in label_names for la in l]
 
     lh_labels = [name + '-lh' for name in label_names]
@@ -909,14 +909,14 @@ def plot_degree_circle(degrees, yaml_fname, orig_labels_fname,
 
     # the respective no. of regions in each cortex
     # yaml fix order change
-    group_numbers = [len(list(key.values())[0]) for key in labels]
+    group_numbers = [len(list(group.values())[0]) for group in label_groups]
     group_numbers = group_numbers[::-1] + group_numbers
 
     node_angles, node_colors = _get_node_angles_and_colors(group_numbers, cortex_colors,
                                                            node_order, orig_labels)
 
     # prepare group label positions
-    group_labels = [list(lab.keys())[0] for lab in labels]
+    group_labels = [list(group.keys())[0] for group in label_groups]
     grp_lh_labels = [name + '-lh' for name in group_labels]
     grp_rh_labels = [name + '-rh' for name in group_labels]
     all_group_labels = grp_lh_labels + grp_rh_labels
@@ -1011,13 +1011,13 @@ def plot_lines_and_blobs(con, degrees, yaml_fname, orig_labels_fname,
     # read the yaml file with grouping of the various nodes
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:
-            labels = yaml.safe_load(f)
+            label_groups = yaml.safe_load(f)
     else:
         print('%s - File not found.' % yaml_fname)
         sys.exit()
 
     # make list of label_names (without individual cortex locations)
-    label_names = [list(lab.values())[0] for lab in labels]
+    label_names = [list(group.values())[0] for group in label_groups]
     label_names = [la for l in label_names for la in l]
 
     lh_labels = [name + '-lh' for name in label_names if name + '-lh' in orig_labels]
@@ -1032,14 +1032,14 @@ def plot_lines_and_blobs(con, degrees, yaml_fname, orig_labels_fname,
 
     group_bound = [0]
     # left first in reverse order, then right hemi labels
-    for i in range(len(labels))[::-1]:
-        cortical_region = list(labels[i].keys())[0]
-        actual_num_lh = [rlab for rlab in labels[i][cortical_region] if rlab + '-lh' in lh_labels]
+    for i in range(len(label_groups))[::-1]:
+        cortical_region = list(label_groups[i].keys())[0]
+        actual_num_lh = [rlab for rlab in label_groups[i][cortical_region] if rlab + '-lh' in lh_labels]
         group_bound.append(len(actual_num_lh))
 
-    for i in range(len(labels)):
-        cortical_region = list(labels[i].keys())[0]
-        actual_num_rh = [rlab for rlab in labels[i][cortical_region] if rlab + '-rh' in rh_labels]
+    for i in range(len(label_groups)):
+        cortical_region = list(label_groups[i].keys())[0]
+        actual_num_rh = [rlab for rlab in label_groups[i][cortical_region] if rlab + '-rh' in rh_labels]
         group_bound.append(len(actual_num_rh))
 
     assert np.sum(group_bound) == len(orig_labels), 'Mismatch in number of labels when computing group boundaries.'
@@ -1069,7 +1069,7 @@ def plot_lines_and_blobs(con, degrees, yaml_fname, orig_labels_fname,
         node_width = node_width * np.pi / 180
 
     # prepare group label positions
-    group_labels = [list(lab.keys())[0] for lab in labels]
+    group_labels = [list(group.keys())[0] for group in label_groups]
     grp_lh_labels = [name + '-lh' for name in group_labels]
     grp_rh_labels = [name + '-rh' for name in group_labels]
     all_group_labels = grp_lh_labels + grp_rh_labels
@@ -1664,7 +1664,7 @@ def plot_labelled_group_connectivity_circle(yaml_fname, con, orig_labels,
     # read the yaml file with grouping
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:
-            labels = yaml.safe_load(f)
+            label_groups = yaml.safe_load(f)
     else:
         print('%s - File not found.' % yaml_fname)
         sys.exit()
@@ -1674,13 +1674,13 @@ def plot_labelled_group_connectivity_circle(yaml_fname, con, orig_labels,
 
     # make list of label_names (without individual cortex locations)
     label_names = list()
-    for lab in labels:
-        label_names.extend(labels[lab])
+    for group in label_groups:
+        label_names.extend(label_groups[group])
 
     lh_labels = [name + '-lh' for name in label_names]
     rh_labels = [name + '-rh' for name in label_names]
 
-    group_labels = list(labels.keys())
+    group_labels = list(label_groups.keys())
     grp_lh_labels = [name + '-lh' for name in group_labels]
     grp_rh_labels = [name + '-rh' for name in group_labels]
 
@@ -1701,7 +1701,7 @@ def plot_labelled_group_connectivity_circle(yaml_fname, con, orig_labels,
                                         start_pos=90.)
 
     # the respective no. of regions in each cortex
-    group_bound = [len(labels[key]) for key in list(labels.keys())]
+    group_bound = [len(label_groups[key]) for key in list(label_groups.keys())]
     group_bound = [0] + group_bound[::-1] + group_bound
 
     group_boundaries = [sum(group_bound[:i+1])
@@ -1742,7 +1742,7 @@ def plot_labelled_group_connectivity_circle(yaml_fname, con, orig_labels,
         import matplotlib.patches as mpatches
         legend_patches = [mpatches.Patch(color=col, label=key)
                           for col, key in zip(['g', 'r', 'c', 'y', 'b', 'm'],
-                                              list(labels.keys()))]
+                                              list(label_groups.keys()))]
         plt.legend(handles=legend_patches, loc=(0.02, 0.02), ncol=1,
                    mode=None, fontsize='small')
     if out_fname:
@@ -1770,7 +1770,7 @@ def plot_fica_grouped_circle(yaml_fname, con, orig_labels, node_order_size,
     # read the yaml file with grouping
     if op.isfile(yaml_fname):
         with open(yaml_fname, 'r') as f:
-            labels = yaml.safe_load(f)
+            label_groups = yaml.safe_load(f)
     else:
         print('%s - File not found.' % yaml_fname)
         sys.exit()
@@ -1779,10 +1779,10 @@ def plot_fica_grouped_circle(yaml_fname, con, orig_labels, node_order_size,
 
     # make list of label_names (without individual cortex locations)
     label_names = list()
-    for lab in labels:
-        label_names.extend(labels[lab])
+    for group in label_groups:
+        label_names.extend(label_groups[group])
 
-    group_labels = list(labels.keys())
+    group_labels = list(label_groups.keys())
 
     # Save the plot order and create a circular layout
     node_order = label_names
@@ -1797,7 +1797,7 @@ def plot_fica_grouped_circle(yaml_fname, con, orig_labels, node_order_size,
                                         start_pos=75.)
 
     # the respective no. of regions in each cortex
-    group_bound = [len(labels[key]) for key in list(labels.keys())]
+    group_bound = [len(label_groups[key]) for key in list(label_groups.keys())]
     group_bound = [0] + group_bound
     # group_bound = [0] + group_bound[::-1] + group_bound
 
@@ -1839,7 +1839,7 @@ def plot_fica_grouped_circle(yaml_fname, con, orig_labels, node_order_size,
         import matplotlib.patches as mpatches
         legend_patches = [mpatches.Patch(color=col, label=key)
                           for col, key in zip(['g', 'r', 'c', 'y', 'b', 'm'],
-                                              list(labels.keys()))]
+                                              list(label_groups.keys()))]
         plt.legend(handles=legend_patches, loc=(0.02, 0.02), ncol=1,
                    mode=None, fontsize='small')
     if out_fname:


### PR DESCRIPTION
Some refactoring in con_viz.py that should make things a little easier to understand

1. removed argument node_order_size in plot_grouped_connectivity_circle() as it simply depended on the number of labels
2. renamed labels in plot_grouped_connectivity_circle() to label_groups to avoid confusion with actual labels
3. made separate function _get_node_grouping()